### PR TITLE
fix for Arduino IDE

### DIFF
--- a/src/S9706.h
+++ b/src/S9706.h
@@ -1,6 +1,8 @@
 #ifndef S9706_h
 #define S9706_h
 
+#include "Arduino.h"
+
 #define S9706_MODE_HIGH 1
 #define S9706_MODE_LOW  2
 


### PR DESCRIPTION
- error message: "'uint_8t' does not name a type"
